### PR TITLE
Add expo-camera maven repository

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,10 @@ allprojects {
             // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
             url "$rootDir/../node_modules/react-native/android"
         }
+        maven {
+            // expo-camera bundles a custom com.google.android:cameraview
+            url "$rootDir/../node_modules/expo-camera/android/maven"
+        }
     }
 }
 


### PR DESCRIPTION
`expo-camera` bundles a custom `com.google.android:cameraview` in its Maven repository so we need to instruct the Android project it should look for the dependencies there too.